### PR TITLE
🐛 Install module before running app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ RUN pip install \
     pylint \
     pytest \
     pytest-cov
-CMD ["python", "-m", "api"]
+CMD ["make", "start"]

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ all: check coverage mutants
 	install \
 	linter \
 	mutants \
+	start \
 	tests
 
 module = tablero
@@ -59,6 +60,9 @@ linter:
 
 mutants: install
 	mutmut run --paths-to-mutate ${module}
+
+start: install
+	python -m api
 
 tests: install
 	pytest --cov=tablero --cov-report=term --verbose


### PR DESCRIPTION
El contenedor amaneció caído. Lo rompimos en el lanzamiento de la versión 0.1.0. Este PR lo repara.